### PR TITLE
fix listContents() for subdirectories if parent is uppercase

### DIFF
--- a/src/DropboxAdapter.php
+++ b/src/DropboxAdapter.php
@@ -243,6 +243,7 @@ class DropboxAdapter extends AbstractAdapter
 
         foreach ($result['contents'] as $object) {
             $path = $this->removePathPrefix($object['path']);
+            $path = str_replace(mb_strtolower($directory), $directory, $path);
             $listing[] = $this->normalizeResponse($object, $path);
 
             if ($recursive && $object['is_dir']) {

--- a/tests/DropboxAdapterTests.php
+++ b/tests/DropboxAdapterTests.php
@@ -180,16 +180,19 @@ class DropboxTests extends PHPUnit_Framework_TestCase
     {
         $mock->shouldReceive('getMetadataWithChildren')->andReturn(
             ['contents' => [
-                ['is_dir' => true, 'path' => 'dirname'],
+                ['is_dir' => true, 'path' => 'Root/dirname'],
             ]],
             ['contents' => [
-                ['is_dir' => false, 'path' => 'dirname/file'],
+                ['is_dir' => false, 'path' => 'root/dirname/file'],
             ]],
             false
         );
 
+        $adapter->setPathPrefix(null);
         $result = $adapter->listContents('', true);
         $this->assertCount(2, $result);
+        $this->assertEquals('Root/dirname/file', $result[1]['path']);
+
         $this->assertEquals([], $adapter->listContents('', false));
     }
 


### PR DESCRIPTION
Let's say we have file `Foo/bar/baz.txt` on dropbox. Then

``` php
$adapter = new DropboxAdapter(…);
$filesystem = new Filesystem($adapter);
$filesystem->listContents('Foo/bar');
```

returns an empty array.

The problem is that the dropbox API returns the `path` as lowercase: `foo/bar`. `League\Flysystem::listContents()` then filters the content out because it compares 'Foo/bar' to 'foo/bar'.
