### PR TITLE
Provide the size of the stream if available.

### DIFF
--- a/src/DropboxAdapter.php
+++ b/src/DropboxAdapter.php
@@ -300,7 +300,10 @@ class DropboxAdapter extends AbstractAdapter
     {
         $location = $this->applyPathPrefix($path);
 
-        if (! $result = $this->client->uploadFile($location, $mode, $resource)) {
+        // If size is zero, consider it unknown.
+        $size = Util::getStreamSize($resource) ?: null;
+
+        if (! $result = $this->client->uploadFile($location, $mode, $resource, $size)) {
             return false;
         }
 

--- a/tests/DropboxAdapterTests.php
+++ b/tests/DropboxAdapterTests.php
@@ -71,11 +71,11 @@ class DropboxTests extends PHPUnit_Framework_TestCase
             'modified' => '10 September 2000',
         ], false);
 
-        $result = $adapter->writeStream('something', 'contents', new Config());
+        $result = $adapter->writeStream('something', tmpfile(), new Config());
         $this->assertInternalType('array', $result);
         $this->assertArrayHasKey('type', $result);
         $this->assertEquals('file', $result['type']);
-        $this->assertFalse($adapter->writeStream('something', 'something', new Config()));
+        $this->assertFalse($adapter->writeStream('something', tmpfile(), new Config()));
     }
 
     /**
@@ -88,11 +88,11 @@ class DropboxTests extends PHPUnit_Framework_TestCase
             'modified' => '10 September 2000',
         ], false);
 
-        $result = $adapter->updateStream('something', 'contents', new Config());
+        $result = $adapter->updateStream('something', tmpfile(), new Config());
         $this->assertInternalType('array', $result);
         $this->assertArrayHasKey('type', $result);
         $this->assertEquals('file', $result['type']);
-        $this->assertFalse($adapter->updateStream('something', 'something', new Config()));
+        $this->assertFalse($adapter->updateStream('something', tmpfile(), new Config()));
     }
 
     public function metadataProvider()


### PR DESCRIPTION
According to Dropbox\Client::uploadFile(), if we provide the size of the stream, it can use a more efficient upload method.

This checks the size of the stream using fstat(), if it is zero, we assume the stream doesn't provide the size.
