### PR TITLE
Check proper return value of Dropbox client delete method.

### DIFF
--- a/src/DropboxAdapter.php
+++ b/src/DropboxAdapter.php
@@ -154,8 +154,9 @@ class DropboxAdapter extends AbstractAdapter
     public function delete($path)
     {
         $location = $this->applyPathPrefix($path);
+        $result = $this->client->delete($location);
 
-        return $this->client->delete($location);
+        return isset($result['is_deleted']) ? $result['is_deleted'] : false;
     }
 
     /**

--- a/tests/DropboxAdapterTests.php
+++ b/tests/DropboxAdapterTests.php
@@ -147,7 +147,7 @@ class DropboxTests extends PHPUnit_Framework_TestCase
      */
     public function testDelete(Dropbox $adapter, $mock)
     {
-        $mock->delete('/prefix/something')->willReturn(true);
+        $mock->delete('/prefix/something')->willReturn(['is_deleted' => true]);
         $this->assertTrue($adapter->delete('something'));
         $this->assertTrue($adapter->deleteDir('something'));
     }


### PR DESCRIPTION
According to http://dropbox.github.io/dropbox-sdk-php/api-docs/v1.1.x/source-class-Dropbox.Client.html#1274-1303, the delete method doesn't return a bool, but rather an array of info.
