### PR TITLE
Add abandon message

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
     },
     "min-stability": "dev",
     "prefer-stable": true,
+    "abandon": "This package will stop working after 28 june 2017. Use spatie/flystem-dropbox after that date"
     "extra": {
         "branch-alias": {
             "dev-master": "1.0-dev"


### PR DESCRIPTION
On 28th of June Dropbox will shut down v1 of their API. 

If I'm not mistaken there are no plans to update this package anymore.

Therefore it's best to abandon this message some time before the date so users see the abandon message when installing or updating their dependencies.  I was so free to add a replacement suggestion in the message 😎 